### PR TITLE
Fr/main scripts

### DIFF
--- a/dataset/acero rubrum/001.json
+++ b/dataset/acero rubrum/001.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.042518728487548084, "px_height_in_mm": 0.04283241995961927}}

--- a/dataset/acero rubrum/002.json
+++ b/dataset/acero rubrum/002.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.042988741044012284, "px_height_in_mm": 0.0430622009569378}}

--- a/dataset/acero rubrum/003.json
+++ b/dataset/acero rubrum/003.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04216867469879518, "px_height_in_mm": 0.04233181299885975}}

--- a/dataset/acero rubrum/004.json
+++ b/dataset/acero rubrum/004.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04261363636363636, "px_height_in_mm": 0.04296875}}

--- a/dataset/acero rubrum/005.json
+++ b/dataset/acero rubrum/005.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.041526596796519676, "px_height_in_mm": 0.0425075139544869}}

--- a/dataset/acero rubrum/006.json
+++ b/dataset/acero rubrum/006.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.041716328963051254, "px_height_in_mm": 0.04170762533352057}}

--- a/dataset/acero rubrum/007.json
+++ b/dataset/acero rubrum/007.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.042042042042042045, "px_height_in_mm": 0.04253186309609051}}

--- a/dataset/acero rubrum/008.json
+++ b/dataset/acero rubrum/008.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04063467492260062, "px_height_in_mm": 0.041318864774624375}}

--- a/dataset/acero rubrum/009.json
+++ b/dataset/acero rubrum/009.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04263959390862944, "px_height_in_mm": 0.04299985521934269}}

--- a/dataset/acero rubrum/010.json
+++ b/dataset/acero rubrum/010.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04329004329004329, "px_height_in_mm": 0.043908929627439384}}

--- a/dataset/agrifoglio/001.json
+++ b/dataset/agrifoglio/001.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.07868115399025852, "px_height_in_mm": 0.07903139968068121}}

--- a/dataset/agrifoglio/002.json
+++ b/dataset/agrifoglio/002.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.08136381247578459, "px_height_in_mm": 0.08206686930091185}}

--- a/dataset/agrifoglio/003.json
+++ b/dataset/agrifoglio/003.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.08437123342707915, "px_height_in_mm": 0.08456719817767654}}

--- a/dataset/agrifoglio/004.json
+++ b/dataset/agrifoglio/004.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.08775595486836607, "px_height_in_mm": 0.0883402736466389}}

--- a/dataset/agrifoglio/005.json
+++ b/dataset/agrifoglio/005.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.1025390625, "px_height_in_mm": 0.08233989464929305}}

--- a/dataset/agrifoglio/006.json
+++ b/dataset/agrifoglio/006.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.08373205741626795, "px_height_in_mm": 0.08375634517766498}}

--- a/dataset/agrifoglio/007.json
+++ b/dataset/agrifoglio/007.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.11811023622047244, "px_height_in_mm": 0.08387461169161253}}

--- a/dataset/agrifoglio/008.json
+++ b/dataset/agrifoglio/008.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.08, "px_height_in_mm": 0.08119190814652816}}

--- a/dataset/agrifoglio/009.json
+++ b/dataset/agrifoglio/009.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.08564437194127243, "px_height_in_mm": 0.0858877964141122}}

--- a/dataset/agrifoglio/010.json
+++ b/dataset/agrifoglio/010.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.08488278092158448, "px_height_in_mm": 0.08527131782945736}}

--- a/dataset/faggio/001.json
+++ b/dataset/faggio/001.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03468780971258672, "px_height_in_mm": 0.05750242013552759}}

--- a/dataset/faggio/002.json
+++ b/dataset/faggio/002.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03676470588235294, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/faggio/003.json
+++ b/dataset/faggio/003.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/faggio/004.json
+++ b/dataset/faggio/004.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/faggio/005.json
+++ b/dataset/faggio/005.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/faggio/006.json
+++ b/dataset/faggio/006.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/faggio/007.json
+++ b/dataset/faggio/007.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.0352763312615488, "px_height_in_mm": 0.044755877034358044}}

--- a/dataset/faggio/008.json
+++ b/dataset/faggio/008.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/faggio/009.json
+++ b/dataset/faggio/009.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/faggio/010.json
+++ b/dataset/faggio/010.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/frassino/001.json
+++ b/dataset/frassino/001.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/frassino/002.json
+++ b/dataset/frassino/002.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.034173282706247844}}

--- a/dataset/frassino/003.json
+++ b/dataset/frassino/003.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/frassino/004.json
+++ b/dataset/frassino/004.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/frassino/005.json
+++ b/dataset/frassino/005.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/frassino/006.json
+++ b/dataset/frassino/006.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/frassino/007.json
+++ b/dataset/frassino/007.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/frassino/008.json
+++ b/dataset/frassino/008.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/frassino/009.json
+++ b/dataset/frassino/009.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/frassino/010.json
+++ b/dataset/frassino/010.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.03027681660899654, "px_height_in_mm": 0.032115051903114186}}

--- a/dataset/gaggia/001.json
+++ b/dataset/gaggia/001.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04305043050430504, "px_height_in_mm": 0.04323773475032756}}

--- a/dataset/gaggia/002.json
+++ b/dataset/gaggia/002.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04168320762207225, "px_height_in_mm": 0.04169006176305446}}

--- a/dataset/gaggia/003.json
+++ b/dataset/gaggia/003.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.042134831460674156, "px_height_in_mm": 0.039924721064659226}}

--- a/dataset/gaggia/004.json
+++ b/dataset/gaggia/004.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04533678756476684, "px_height_in_mm": 0.04564315352697095}}

--- a/dataset/gaggia/005.json
+++ b/dataset/gaggia/005.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04163362410785091, "px_height_in_mm": 0.04186046511627907}}

--- a/dataset/gaggia/006.json
+++ b/dataset/gaggia/006.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04316546762589928, "px_height_in_mm": 0.04370860927152318}}

--- a/dataset/gaggia/007.json
+++ b/dataset/gaggia/007.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.042134831460674156, "px_height_in_mm": 0.0424831926762981}}

--- a/dataset/gaggia/008.json
+++ b/dataset/gaggia/008.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.043209876543209874, "px_height_in_mm": 0.04365721005438777}}

--- a/dataset/gaggia/009.json
+++ b/dataset/gaggia/009.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04140378548895899, "px_height_in_mm": 0.04427549194991055}}

--- a/dataset/gaggia/010.json
+++ b/dataset/gaggia/010.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04395144411887819, "px_height_in_mm": 0.04415043853129181}}

--- a/dataset/liquidambar/001.json
+++ b/dataset/liquidambar/001.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04270028466856446, "px_height_in_mm": 0.042193493393948005}}

--- a/dataset/liquidambar/002.json
+++ b/dataset/liquidambar/002.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04065040650406504, "px_height_in_mm": 0.04186046511627907}}

--- a/dataset/liquidambar/003.json
+++ b/dataset/liquidambar/003.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04054054054054054, "px_height_in_mm": 0.04202037351443124}}

--- a/dataset/liquidambar/004.json
+++ b/dataset/liquidambar/004.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04140378548895899, "px_height_in_mm": 0.04237409045512912}}

--- a/dataset/liquidambar/005.json
+++ b/dataset/liquidambar/005.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.042042042042042045, "px_height_in_mm": 0.042301666429283576}}

--- a/dataset/liquidambar/006.json
+++ b/dataset/liquidambar/006.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.041128084606345476, "px_height_in_mm": 0.0416141235813367}}

--- a/dataset/liquidambar/007.json
+++ b/dataset/liquidambar/007.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.041363009651368916, "px_height_in_mm": 0.041376427974366116}}

--- a/dataset/liquidambar/008.json
+++ b/dataset/liquidambar/008.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04286589099816289, "px_height_in_mm": 0.04289428076256499}}

--- a/dataset/liquidambar/009.json
+++ b/dataset/liquidambar/009.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04129793510324484, "px_height_in_mm": 0.04142259414225941}}

--- a/dataset/liquidambar/010.json
+++ b/dataset/liquidambar/010.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04212637913741224, "px_height_in_mm": 0.0424831926762981}}

--- a/dataset/mirtillo/001.json
+++ b/dataset/mirtillo/001.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04554326610279766, "px_height_in_mm": 0.04557311646463096}}

--- a/dataset/mirtillo/002.json
+++ b/dataset/mirtillo/002.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04248432126239126, "px_height_in_mm": 0.04286332804156444}}

--- a/dataset/mirtillo/003.json
+++ b/dataset/mirtillo/003.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04187437686939183, "px_height_in_mm": 0.041889985895627646}}

--- a/dataset/mirtillo/004.json
+++ b/dataset/mirtillo/004.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.042151746286631875, "px_height_in_mm": 0.04286332804156444}}

--- a/dataset/mirtillo/005.json
+++ b/dataset/mirtillo/005.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04163362410785091, "px_height_in_mm": 0.04303100550565054}}

--- a/dataset/mirtillo/006.json
+++ b/dataset/mirtillo/006.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04263959390862944, "px_height_in_mm": 0.04347189695550351}}

--- a/dataset/mirtillo/007.json
+++ b/dataset/mirtillo/007.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.041791044776119404, "px_height_in_mm": 0.042103770910121914}}

--- a/dataset/mirtillo/008.json
+++ b/dataset/mirtillo/008.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.041501976284584984, "px_height_in_mm": 0.04288808664259928}}

--- a/dataset/mirtillo/009.json
+++ b/dataset/mirtillo/009.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04163362410785091, "px_height_in_mm": 0.04183098591549296}}

--- a/dataset/mirtillo/010.json
+++ b/dataset/mirtillo/010.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.042151746286631875, "px_height_in_mm": 0.04242857142857143}}

--- a/dataset/salvia/001.json
+++ b/dataset/salvia/001.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04389632107023411, "px_height_in_mm": 0.04401304090100771}}

--- a/dataset/salvia/002.json
+++ b/dataset/salvia/002.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04160063391442155, "px_height_in_mm": 0.043049717350340626}}

--- a/dataset/salvia/003.json
+++ b/dataset/salvia/003.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.044642857142857144, "px_height_in_mm": 0.044830188679245285}}

--- a/dataset/salvia/004.json
+++ b/dataset/salvia/004.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.042151746286631875, "px_height_in_mm": 0.04466837118363664}}

--- a/dataset/salvia/005.json
+++ b/dataset/salvia/005.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04504504504504504, "px_height_in_mm": 0.045260591283145385}}

--- a/dataset/salvia/006.json
+++ b/dataset/salvia/006.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.0434063662670525, "px_height_in_mm": 0.043567551708962884}}

--- a/dataset/salvia/007.json
+++ b/dataset/salvia/007.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.0435052827843381, "px_height_in_mm": 0.04344645991808075}}

--- a/dataset/salvia/008.json
+++ b/dataset/salvia/008.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04163362410785091, "px_height_in_mm": 0.04129014319477269}}

--- a/dataset/salvia/009.json
+++ b/dataset/salvia/009.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04196642685851319, "px_height_in_mm": 0.04198473282442748}}

--- a/dataset/salvia/010.json
+++ b/dataset/salvia/010.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04280472890338361, "px_height_in_mm": 0.04291907514450867}}

--- a/dataset/ulivo/001.json
+++ b/dataset/ulivo/001.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04468085106382979, "px_height_in_mm": 0.04496593489780469}}

--- a/dataset/ulivo/002.json
+++ b/dataset/ulivo/002.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.0429535692370628, "px_height_in_mm": 0.04309344167150319}}

--- a/dataset/ulivo/003.json
+++ b/dataset/ulivo/003.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.041592394533571005, "px_height_in_mm": 0.04407836153161175}}

--- a/dataset/ulivo/004.json
+++ b/dataset/ulivo/004.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.041824337781318464, "px_height_in_mm": 0.04183098591549296}}

--- a/dataset/ulivo/005.json
+++ b/dataset/ulivo/005.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.0435052827843381, "px_height_in_mm": 0.04434159450582263}}

--- a/dataset/ulivo/006.json
+++ b/dataset/ulivo/006.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.041708043694141016, "px_height_in_mm": 0.04272766508416055}}

--- a/dataset/ulivo/007.json
+++ b/dataset/ulivo/007.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04585152838427948, "px_height_in_mm": 0.04686760296670349}}

--- a/dataset/ulivo/008.json
+++ b/dataset/ulivo/008.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04354136429608128, "px_height_in_mm": 0.04403914590747331}}

--- a/dataset/ulivo/009.json
+++ b/dataset/ulivo/009.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.04552352048558422, "px_height_in_mm": 0.046017973349860554}}

--- a/dataset/ulivo/010.json
+++ b/dataset/ulivo/010.json
@@ -1,0 +1,1 @@
+{"features": {}, "internal": {"px_width_in_mm": 0.043777360850531584, "px_height_in_mm": 0.04417670682730924}}

--- a/functions/features.py
+++ b/functions/features.py
@@ -4,6 +4,7 @@ from cv2.typing import MatLike
 from typing import Optional, Any
 
 import json
+import cv2
 
 from functions.lengths.px_size import get_px_height_in_mm, get_px_width_in_mm
 
@@ -30,7 +31,7 @@ class ImageFeatures:
     """
 
     def __init__(self, img: MatLike) -> None:
-        # Image
+        # Image, in BGR
         self.__img = img
 
         # Modified flag
@@ -108,7 +109,9 @@ class ImageFeatures:
         if self.__px_width_in_mm:
             return self.__px_width_in_mm
 
-        self.__px_width_in_mm = get_px_width_in_mm(self.__img)
+        self.__px_width_in_mm = get_px_width_in_mm(
+            cv2.cvtColor(self.__img, cv2.COLOR_BGR2HSV)
+        )
         self.__modified = True
         return self.__px_width_in_mm
 
@@ -116,6 +119,8 @@ class ImageFeatures:
         if self.__px_height_in_mm:
             return self.__px_height_in_mm
 
-        self.__px_height_in_mm = get_px_height_in_mm(self.__img)
+        self.__px_height_in_mm = get_px_height_in_mm(
+            cv2.cvtColor(self.__img, cv2.COLOR_BGR2HSV)
+        )
         self.__modified = True
         return self.__px_height_in_mm

--- a/functions/features.py
+++ b/functions/features.py
@@ -73,10 +73,6 @@ class ImageFeatures:
         if internals.get("px_width_in_mm", None):
             self.__px_width_in_mm = internals["px_width_in_mm"]
 
-        print(internals)
-        print(internals.get("px_height_in_mm", None))
-        print(bool(internals.get("px_height_in_mm", None)))
-
         if internals.get("px_height_in_mm", None):
             self.__px_height_in_mm = internals["px_height_in_mm"]
 

--- a/functions/features.py
+++ b/functions/features.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from cv2.typing import MatLike
+from typing import Optional, Any
+
+import json
+
+# from functions.lengths.px_size import get_px_height_in_mm, get_px_width_in_mm
+
+
+def get_px_height_in_mm(img: MatLike) -> float:
+    return 0.0
+
+
+def get_px_width_in_mm(img: MatLike) -> float:
+    return 0.0
+
+
+class ImageFeatures:
+    """
+    An ImageFeature is an object that stores an image, and allows you to
+    compute all its features.
+    The features are cached, stored in attributes of the class, if
+    already computed. The various get methods will check if the value is
+    present, and if it is not, they will call the appropriate function,
+    store the result and return it.
+    It is also possible to store an ImageFeatures to a file, and to load
+    it from a file.
+
+    ---------------------------------------------------------------------
+    What to do when adding a new feature/internal measure to an image:
+    - add it as an attribute, either in the "internal values" or in the
+        "model features" section. It must be an Optional[type]
+    - add the getters for the value, that also update the attribute
+    - add the getter to the correct location in the dict in to_JSON
+    - add a parser in from_file
+    """
+
+    def __init__(self, img: MatLike) -> None:
+        # Image
+        self.__img = img
+
+        # Internal values
+        self.__px_width_in_mm: Optional[float] = None
+        self.__px_height_in_mm: Optional[float] = None
+
+        # Model features
+
+    def to_JSON(self) -> str:
+        res: dict[str, dict[str, Any]] = {
+            "features": {},
+            "internal": {
+                "px_width_in_mm": self.__get_px_width_in_mm(),
+                "px_height_in_mm": self.__get_px_height_in_mm(),
+            },
+        }
+
+        return json.dumps(res)
+
+    def load_details_from_file(self, path: str) -> ImageFeatures:
+        """
+        Given an existing ImageFeatures and the path of the corresponding
+        json file, updates the attributes with the values stored in the json
+        file, leaving None to what is not present in the json file
+
+        ---------------------------------------------------------------------
+        PARAMETERS
+        ----------
+        - path: the path to the json file
+
+        ---------------------------------------------------------------------
+        OUTPUT
+        ------
+        The ImageFeatures itself, to be able to do method chaining
+        """
+        with open(path, "r") as file:
+            data = json.load(file)
+
+        internals, features = data["internal"], data["features"]
+
+        if internals.get("px_width_in_mm", None):
+            self.__px_width_in_mm = internals["px_width_in_mm"]
+
+        print(internals)
+        print(internals.get("px_height_in_mm", None))
+        print(bool(internals.get("px_height_in_mm", None)))
+
+        if internals.get("px_height_in_mm", None):
+            self.__px_height_in_mm = internals["px_height_in_mm"]
+
+        return self
+
+    def store_to_file(self, path: str) -> None:
+        """
+        Stores all the data to a file, in json format
+
+        ---------------------------------------------------------------------
+        PARAMETERS
+        ----------
+        - path: the path of the file where to write
+        """
+
+        with open(path, "w") as f:
+            f.write(self.to_JSON())
+
+    def __get_px_width_in_mm(self) -> float:
+        if self.__px_width_in_mm:
+            return self.__px_width_in_mm
+
+        self.__px_width_in_mm = get_px_width_in_mm(self.__img)
+        return self.__px_width_in_mm
+
+    def __get_px_height_in_mm(self) -> float:
+        if self.__px_height_in_mm:
+            return self.__px_height_in_mm
+
+        self.__px_height_in_mm = get_px_height_in_mm(self.__img)
+        return self.__px_height_in_mm

--- a/functions/features.py
+++ b/functions/features.py
@@ -33,7 +33,7 @@ class ImageFeatures:
         "model features" section. It must be an Optional[type]
     - add the getters for the value, that also update the attribute
     - add the getter to the correct location in the dict in to_JSON
-    - add a parser in from_file
+    - add a parser in load_details_from_file
     """
 
     def __init__(self, img: MatLike) -> None:

--- a/functions/features.py
+++ b/functions/features.py
@@ -5,15 +5,7 @@ from typing import Optional, Any
 
 import json
 
-# from functions.lengths.px_size import get_px_height_in_mm, get_px_width_in_mm
-
-
-def get_px_height_in_mm(img: MatLike) -> float:
-    return 0.0
-
-
-def get_px_width_in_mm(img: MatLike) -> float:
-    return 0.0
+from functions.lengths.px_size import get_px_height_in_mm, get_px_width_in_mm
 
 
 class ImageFeatures:

--- a/functions/features.py
+++ b/functions/features.py
@@ -23,7 +23,8 @@ class ImageFeatures:
     What to do when adding a new feature/internal measure to an image:
     - add it as an attribute, either in the "internal values" or in the
         "model features" section. It must be an Optional[type]
-    - add the getters for the value, that also update the attribute
+    - add the getters for the value, that also update the attribute and
+        set self.__modified to True if the value was changed
     - add the getter to the correct location in the dict in to_JSON
     - add a parser in load_details_from_file
     """
@@ -31,6 +32,9 @@ class ImageFeatures:
     def __init__(self, img: MatLike) -> None:
         # Image
         self.__img = img
+
+        # Modified flag
+        self.__modified: bool = False
 
         # Internal values
         self.__px_width_in_mm: Optional[float] = None
@@ -78,24 +82,34 @@ class ImageFeatures:
 
         return self
 
-    def store_to_file(self, path: str) -> None:
+    def store_to_file(self, path: str, force: bool = False) -> None:
         """
-        Stores all the data to a file, in json format
+        Stores all the data to a file, in json format.
+        If all the values were already loaded from a file (no recomputation),
+        the file will not be written by default.
+        The write can occur also if all the values were loaded, if the force
+        flag is set.
 
         ---------------------------------------------------------------------
         PARAMETERS
         ----------
         - path: the path of the file where to write
+        - force: if set, the file will be written regardless of whether the
+            values were computed or not
         """
 
-        with open(path, "w") as f:
-            f.write(self.to_JSON())
+        result = self.to_JSON()
+
+        if force or self.__modified:
+            with open(path, "w") as f:
+                f.write(result)
 
     def __get_px_width_in_mm(self) -> float:
         if self.__px_width_in_mm:
             return self.__px_width_in_mm
 
         self.__px_width_in_mm = get_px_width_in_mm(self.__img)
+        self.__modified = True
         return self.__px_width_in_mm
 
     def __get_px_height_in_mm(self) -> float:
@@ -103,4 +117,5 @@ class ImageFeatures:
             return self.__px_height_in_mm
 
         self.__px_height_in_mm = get_px_height_in_mm(self.__img)
+        self.__modified = True
         return self.__px_height_in_mm

--- a/functions/lengths/px_counting.py
+++ b/functions/lengths/px_counting.py
@@ -16,7 +16,7 @@ def count_paper_pixels_at_row(img: MatLike, row_no: int) -> Segment:
     ---------------------------------------------------------------------
     Parameters
     ----------
-    - img: the image to be considered, as HSV
+    - img: the image to be considered, in HSV
     - row_no: the index of the row to be considered
 
     ---------------------------------------------------------------------
@@ -37,7 +37,7 @@ def count_paper_pixels_at_col(img: MatLike, col_no: int) -> Segment:
     ---------------------------------------------------------------------
     Parameters
     ----------
-    - img: the image to be considered
+    - img: the image to be considered, in HSV
     - col_no: the index of the column to be considered
 
     ---------------------------------------------------------------------
@@ -62,7 +62,7 @@ def __count_paper_pixels(img: MatLike) -> Segment:
 
     Parameters
     ----------
-    - img: the row of the image to be considered
+    - img: the row of the image to be considered, in HSV
 
     ---------------------------------------------------------------------
     Returns

--- a/functions/lengths/px_size.py
+++ b/functions/lengths/px_size.py
@@ -20,7 +20,7 @@ def get_px_height_in_mm(img: MatLike) -> float:
     ---------------------------------------------------------------------
     Parameters
     ----------
-    - img: the image to be considered
+    - img: the image to be considered, in HSV
 
     ---------------------------------------------------------------------
     Returns
@@ -44,7 +44,7 @@ def get_px_width_in_mm(img: MatLike) -> float:
     ---------------------------------------------------------------------
     Parameters
     ----------
-    - img: the image to be considered
+    - img: the image to be considered, in HSV
 
     ---------------------------------------------------------------------
     Returns

--- a/functions/lengths/px_size.py
+++ b/functions/lengths/px_size.py
@@ -30,11 +30,23 @@ def get_px_height_in_mm(img: MatLike) -> float:
     The average height in mm of a pixel of the picture
     """
 
+    h = img.shape[0]
     w = img.shape[1]
 
     paper_height: int = count_paper_pixels_at_col(img, int(0.5 * w)).length
 
-    return A4_HEIGHT_MM * 1.0 / paper_height
+    res = A4_HEIGHT_MM * 1.0 / paper_height
+    max_reasonable = A4_HEIGHT_MM * 2.0 / h
+
+    # A reasonable maximum is the result that would be obtained when the
+    # paper only occupies half of the picture
+
+    if res > max_reasonable:
+        # there is something wrong, reduce saturation and re-evaluate
+        img[:, :, 1] = img[:, :, 1] / 2  # type: ignore
+        return get_px_height_in_mm(img)
+
+    return res
 
 
 def get_px_width_in_mm(img: MatLike) -> float:
@@ -55,7 +67,19 @@ def get_px_width_in_mm(img: MatLike) -> float:
     """
 
     h = img.shape[0]
+    w = img.shape[1]
 
     paper_width: int = count_paper_pixels_at_row(img, int(0.5 * h)).length
 
-    return A4_WIDTH_MM * 1.0 / paper_width
+    res = A4_WIDTH_MM * 1.0 / paper_width
+    max_reasonable = A4_WIDTH_MM * 2.0 / w
+
+    # A reasonable maximum is the result that would be obtained when the
+    # paper only occupies half of the picture
+
+    if res > max_reasonable:
+        # there is something wrong, reduce saturation and re-evaluate
+        img[:, :, 1] = img[:, :, 1] / 2  # type: ignore
+        return get_px_width_in_mm(img)
+
+    return res

--- a/functions/lengths/px_size.py
+++ b/functions/lengths/px_size.py
@@ -10,6 +10,8 @@ from cv2.typing import MatLike
 A4_WIDTH_MM = 210
 A4_HEIGHT_MM = 297
 
+# TODO: change count functions to more robust ones
+
 
 def get_px_height_in_mm(img: MatLike) -> float:
     """

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from update_dataset import update_dataset
+
+
+if __name__ == "__main__":
+    update_dataset()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,0 @@
-from update_dataset import update_dataset
-
-
-if __name__ == "__main__":
-    update_dataset()

--- a/update_dataset.py
+++ b/update_dataset.py
@@ -1,0 +1,42 @@
+import os
+import cv2
+
+from functions.features import ImageFeatures
+
+
+def update_dataset() -> None:
+    leaves = os.listdir("./dataset")
+
+    for leaf in leaves:
+        files_list = os.listdir(f"./dataset/{leaf}")
+        print(f'Updating dataset for plant "{leaf}"...')
+
+        for img_file_name in files_list:
+            # Do not process json files
+            if img_file_name.endswith(".json"):
+                continue
+
+            img_path = f"./dataset/{leaf}/{img_file_name}"
+            json_path = f"./dataset/{leaf}/{os.path.splitext(img_file_name)[0]}.json"
+
+            img = cv2.imread(img_path)
+            img_features = ImageFeatures(img)
+
+            if os.path.exists(json_path):
+                json_last_modify = os.path.getmtime(json_path)
+                img_last_modify = os.path.getmtime(img_path)
+
+                if img_last_modify < json_last_modify:
+                    # Load json data only if the json exists and the image has not changed since its computation
+                    img_features.load_details_from_file(json_path)
+
+            # If there were updates, update the file
+            img_features.store_to_file(json_path)
+
+        # TODO compute plant summary and percentages
+
+    print(f"Dataset update complete!")
+
+
+if __name__ == "__main__":
+    update_dataset()


### PR DESCRIPTION
Added script that computes all the features (whose code is currently available) and internal values of the images, and stores it in a file for each leaf.
It will need to be improved:
- to save and load the next calculated values
- to compute a recap of all the leaves of a plant
- (?) to compute percentages, usable from the Bayes classifier

The px width&height measurement has also been made stronger, it will no longer return unreasonable values (unreasonable = value that implies that the paper in the image is smaller than half the image itself)